### PR TITLE
Fix/add random field generators

### DIFF
--- a/lib/mix/tasks/gen.ex
+++ b/lib/mix/tasks/gen.ex
@@ -194,6 +194,10 @@ defmodule Mix.Tasks.FactoryEx.Gen do
     "FactoryEx.SchemaCounter.next(\"#{schema_name}_#{field}\")"
   end
 
+  defp build_random_field(:float, _field, _ecto_schema) do
+    "Enum.random(0..99) * :rand.uniform_real()"
+  end
+
   defp build_random_field(:string, field, ecto_schema) do
     ecto_schema = inspect(ecto_schema)
     field_name = "#{FactoryEx.Utils.context_schema_name(ecto_schema)}_#{field}"

--- a/lib/mix/tasks/gen.ex
+++ b/lib/mix/tasks/gen.ex
@@ -231,6 +231,8 @@ defmodule Mix.Tasks.FactoryEx.Gen do
     "Enum.random([#{enum_list}])"
   end
 
+  defp build_random_field(_ecto_type, _field, _ecto_schema), do: "nil"
+
   defp find_faker_function_with_type(field, type) do
     field
       |> matching_faker_functions


### PR DESCRIPTION
This is looking good, thanks for your work on it @MikaAK ! The generator task is very nice. Tried fixing a couple of things I had issues with:

- Avoids errors in the mix generator task with custom ecto types (just sets them to `nil` for now, could do something more complicated with it)
- Adds a `build_random_field` for :floats 🙀 into the generator logic

The build_random output ends up being quite verbose in the generated file. Is there any room for making it more concise?