### PR TITLE
Ensure app modules are compiled

### DIFF
--- a/lib/mix/tasks/gen.ex
+++ b/lib/mix/tasks/gen.ex
@@ -50,6 +50,7 @@ defmodule Mix.Tasks.FactoryEx.Gen do
   end)
 
   def run(args) do
+    Mix.Task.run("app.config", [])
     FactoryExHelpers.ensure_not_in_umbrella!("factory_ex.gen.factory")
 
     {opts, extra_args, _} = OptionParser.parse(args,


### PR DESCRIPTION
Avoids flakiness with compilation and aliasing of modules in the `Module.safe_concat` call in `&Mix.FactoryExHelpers.string_to_module/1` when calling the mix generator task:

```
❯ mix factory_ex.gen --repo Schemas.Repo Schemas.Options.Trade
** (RuntimeError) Module Schemas.Options.Trade doesn't exist
    :erlang.binary_to_existing_atom("Elixir.Schemas.Options.Trade", :utf8)
    lib/mix/factory_ex_helpers.ex:13: Mix.FactoryExHelpers.string_to_module/1
    (elixir 1.13.3) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
    lib/mix/tasks/gen.ex:74: Mix.Tasks.FactoryEx.Gen.run/1
    (mix 1.13.3) lib/mix/task.ex:397: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.13.3) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```